### PR TITLE
Empty tokenizations like the one for "3 2 1" are not handled correctl…

### DIFF
--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -247,7 +247,7 @@ public class Query<E extends Entity> {
         if (Strings.isFilled(query)) {
             this.query = query;
             RobustQueryParser rqp = new RobustQueryParser(defaultField, query, tokenizer, autoexpand);
-            rqp.compileAndApply(this);
+            rqp.compileAndApply(this, false);
         }
 
         return this;
@@ -268,14 +268,9 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> forceQuery(String query, String defaultField, Function<String, Iterable<List<String>>> tokenizer) {
-        String effectiveQuery = (query == null) ? "" : query.replace("*", "").trim();
-        if (effectiveQuery.length() < 3) {
-            fail();
-            return this;
-        }
         this.query = query;
         RobustQueryParser rqp = new RobustQueryParser(defaultField, query, tokenizer, false);
-        rqp.compileAndApply(this);
+        rqp.compileAndApply(this, true);
 
         return this;
     }

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -259,8 +259,7 @@ public class Query<E extends Entity> {
      * <p>
      * If a non-empty query string which contains at least two characters (without "*") is given, this will behave just
      * like {@link #query(String, String, Function, boolean)}. Otherwise the completed query will be failed by calling
-     * {@link
-     * #fail()} to ensure that no results are generated.
+     * {@link #fail()} to ensure that no results are generated.
      *
      * @param query        the query to search for
      * @param defaultField the default field to search in

--- a/src/main/java/sirius/search/RobustQueryParser.java
+++ b/src/main/java/sirius/search/RobustQueryParser.java
@@ -63,10 +63,11 @@ class RobustQueryParser {
     /**
      * Compiles an applies the query to the given one.
      *
-     * @param query the query to enhance with the parsed result
-     * @param force determines if a query was forced, see {@link Query#forceQuery(String, String, Function)}
+     * @param query               the query to enhance with the parsed result
+     * @param failForEmptyQueries determines if a query was forced, see {@link Query#forceQuery(String, String,
+     *                            Function)}
      */
-    void compileAndApply(Query<?> query, boolean force) {
+    void compileAndApply(Query<?> query, boolean failForEmptyQueries) {
         LookaheadReader reader = new LookaheadReader(new StringReader(input));
         QueryBuilder main = parseQuery(reader);
         if (!reader.current().isEndOfInput()) {
@@ -83,7 +84,7 @@ class RobustQueryParser {
                 Index.LOG.FINE("Compiled '%s' into '%s'", query, main);
             }
             query.where(Wrapper.on(main));
-        } else if (force) {
+        } else if (failForEmptyQueries) {
             query.fail();
         }
     }

--- a/src/main/java/sirius/search/RobustQueryParser.java
+++ b/src/main/java/sirius/search/RobustQueryParser.java
@@ -15,6 +15,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.SpanNearQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import parsii.tokenizer.LookaheadReader;
+import sirius.kernel.commons.Strings;
 import sirius.search.constraints.Wrapper;
 
 import java.io.StringReader;
@@ -34,6 +35,7 @@ import java.util.function.Function;
  */
 class RobustQueryParser {
 
+    private static final int EXPANSION_TOKEN_MIN_LENGTH = 2;
     private String defaultField;
     private String input;
     private Function<String, Iterable<List<String>>> tokenizer;
@@ -63,15 +65,25 @@ class RobustQueryParser {
      *
      * @param query the query to enhance with the parsed result
      */
-    void compileAndApply(Query<?> query) {
+    void compileAndApply(Query<?> query, boolean force) {
         LookaheadReader reader = new LookaheadReader(new StringReader(input));
         QueryBuilder main = parseQuery(reader);
         if (!reader.current().isEndOfInput()) {
             Index.LOG.FINE("Unexpected character in query: " + reader.current());
         }
+        // If we cannot compile a query from a non empty input, we probably dropped all short tokens
+        // like a search for "S 8" would be completely dropped. Therefore we resort to "S8".
+        if (main == null && !Strings.isEmpty(input) && input.contains(" ")) {
+            reader = new LookaheadReader(new StringReader(input.replaceAll("\\s", "")));
+            main = parseQuery(reader);
+        }
         if (main != null) {
-            Index.LOG.FINE("Compiled '%s' into '%s'", query, main);
+            if (Index.LOG.isFINE()) {
+                Index.LOG.FINE("Compiled '%s' into '%s'", query, main);
+            }
             query.where(Wrapper.on(main));
+        } else if (force) {
+            query.fail();
         }
     }
 
@@ -89,10 +101,13 @@ class RobustQueryParser {
             skipWhitespace(reader);
 
             List<QueryBuilder> bqb = parseOR(reader);
-            if (bqb != null) {
+            if (!bqb.isEmpty()) {
                 if (bqb.size() == 1) {
-                    if (autoexpand && bqb.get(0) instanceof TermQueryBuilder) {
-                        return QueryBuilders.prefixQuery(defaultField, input.toLowerCase()).rewrite("top_terms_256");
+                    String searchText = input.toLowerCase().trim();
+                    if (autoexpand
+                        && bqb.get(0) instanceof TermQueryBuilder
+                        && searchText.length() >= EXPANSION_TOKEN_MIN_LENGTH) {
+                        return QueryBuilders.prefixQuery(defaultField, searchText).rewrite("top_terms_256");
                     }
                     return bqb.get(0);
                 }
@@ -241,8 +256,15 @@ class RobustQueryParser {
 
     private List<QueryBuilder> compileToken(String field, StringBuilder sb, boolean negate) {
         String value = sb.toString();
-        if (value.length() > 1 && value.endsWith("*")) {
-            return compileTokenWithAsterisk(field, negate, value);
+        if (value.endsWith("*")) {
+            // + 1 to compensate for the "*" in the string
+            if (value.length() >= EXPANSION_TOKEN_MIN_LENGTH + 1) {
+                return compileTokenWithAsterisk(field, negate, value);
+            } else if (value.length() == 1) {
+                return Collections.emptyList();
+            } else {
+                value = value.substring(0, value.length() - 1);
+            }
         }
 
         List<QueryBuilder> result = Lists.newArrayList();
@@ -250,11 +272,13 @@ class RobustQueryParser {
 
         if (field.equals(defaultField)) {
             for (List<String> tokens : tokenizer.apply(value)) {
-                QueryBuilder qb = transformTokenList(field, tokens);
-                if (negate) {
-                    qry.mustNot(qb);
-                } else {
-                    result.add(qb);
+                if (tokens != null && !tokens.isEmpty()) {
+                    QueryBuilder qb = transformTokenList(field, tokens);
+                    if (negate) {
+                        qry.mustNot(qb);
+                    } else {
+                        result.add(qb);
+                    }
                 }
             }
         } else {

--- a/src/main/java/sirius/search/RobustQueryParser.java
+++ b/src/main/java/sirius/search/RobustQueryParser.java
@@ -64,6 +64,7 @@ class RobustQueryParser {
      * Compiles an applies the query to the given one.
      *
      * @param query the query to enhance with the parsed result
+     * @param force determines if a query was forced, see {@link Query#forceQuery(String, String, Function)}
      */
     void compileAndApply(Query<?> query, boolean force) {
         LookaheadReader reader = new LookaheadReader(new StringReader(input));


### PR DESCRIPTION
…y (no empty span query is created). Prefixes now have a min length of 2
