### PR TITLE
Makes DEFAULT_FIELD and defaultAnalyzer() of Query public

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.5.1</version>
+        <version>3.6</version>
     </parent>
     <artifactId>sirius-search</artifactId>
     <version>2.8</version>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>4.7</version>
+            <version>5.3.5</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>[3.1,)</version>
+            <version>3.4</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -36,13 +36,14 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.1.0</version>
+            <version>4.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.module</groupId>
             <artifactId>lang-groovy</artifactId>
-            <version>2.3.1</version>
+            <version>2.4.4</version>
         </dependency>
     </dependencies>
+
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.5.1</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>2.6</version>
+    <version>2.8</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>3.1</version>
+            <version>[3.1,)</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder;
-import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import sirius.kernel.async.ExecutionPoint;
@@ -91,7 +90,7 @@ public class Query<E extends Entity> {
      * Specifies tbe default field to search in used by {@link #query(String)}. Use
      * {@link #query(String, String, Function, boolean, boolean)} to specify a custom field.
      */
-    private static final String DEFAULT_FIELD = "_all";
+    public static final String DEFAULT_FIELD = "_all";
 
     @ConfigValue("index.termFacetLimit")
     private static int termFacetLimit;
@@ -299,7 +298,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> query(String query) {
-        return query(query, DEFAULT_FIELD, this::defaultTokenizer, false, false);
+        return query(query, DEFAULT_FIELD, Query::defaultTokenizer, false, false);
     }
 
     /**
@@ -312,7 +311,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> query(String query, String field) {
-        return query(query, field, this::defaultTokenizer, false, false);
+        return query(query, field, Query::defaultTokenizer, false, false);
     }
 
     /**
@@ -327,7 +326,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> expandedQuery(String query) {
-        return query(query, DEFAULT_FIELD, this::defaultTokenizer, true, false);
+        return query(query, DEFAULT_FIELD, Query::defaultTokenizer, true, false);
     }
 
     /**
@@ -343,7 +342,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> expandedQuery(String query, String field) {
-        return query(query, field, this::defaultTokenizer, true, false);
+        return query(query, field, Query::defaultTokenizer, true, false);
     }
 
     /**
@@ -352,7 +351,7 @@ public class Query<E extends Entity> {
      * @param input the value to tokenize
      * @return a list of token based on the given input
      */
-    private Iterable<List<String>> defaultTokenizer(String input) {
+    public static Iterable<List<String>> defaultTokenizer(String input) {
         List<List<String>> result = Lists.newArrayList();
         StandardAnalyzer std = new StandardAnalyzer();
         try {

--- a/src/main/java/sirius/search/ResultList.java
+++ b/src/main/java/sirius/search/ResultList.java
@@ -9,16 +9,11 @@
 package sirius.search;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.nested.InternalNested;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import sirius.kernel.commons.Monoflop;
-import sirius.kernel.commons.Strings;
 import sirius.search.aggregation.Aggregation;
-import sirius.search.aggregation.bucket.BucketAggregation;
 import sirius.web.controller.Facet;
 
 import java.util.Iterator;

--- a/src/main/java/sirius/search/Schema.java
+++ b/src/main/java/sirius/search/Schema.java
@@ -63,7 +63,6 @@ public class Schema {
     protected Map<String, Class<? extends Entity>> nameTable =
             Collections.synchronizedMap(new HashMap<String, Class<? extends Entity>>());
 
-
     protected Schema(IndexAccess access) {
         this.access = access;
         indexPrefix = Sirius.getConfig().getString("index.prefix");

--- a/src/main/java/sirius/search/aggregation/bucket/FilterAggregation.java
+++ b/src/main/java/sirius/search/aggregation/bucket/FilterAggregation.java
@@ -13,7 +13,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 
 /**
- * Represents an aggregation used to filter for a specific value
+ * Represents an aggregation used to filter for a specific value.
  */
 public class FilterAggregation extends BucketAggregation {
 
@@ -24,7 +24,7 @@ public class FilterAggregation extends BucketAggregation {
     }
 
     /**
-     * Used to generate a filter-aggregation with the given name and on the provided field
+     * Used to generate a filter-aggregation with the given name and on the provided field.
      *
      * @param field the field to be used
      * @param name  the name of the aggregation
@@ -37,7 +37,7 @@ public class FilterAggregation extends BucketAggregation {
     }
 
     /**
-     * Sets the value which is used for filtering
+     * Sets the value which is used for filtering.
      *
      * @param value the used filter value
      * @return the filter-aggregation helper itself for fluent method calls
@@ -48,6 +48,8 @@ public class FilterAggregation extends BucketAggregation {
     }
 
     /**
+     * Returns the filter value.
+     *
      * @return the filter value
      */
     public String getValue() {
@@ -55,10 +57,11 @@ public class FilterAggregation extends BucketAggregation {
     }
 
     /**
-     * Constructs the builder
+     * Constructs the builder.
      *
-     * @return the filter-builder
+     * @return the filter builder
      */
+    @Override
     public FilterAggregationBuilder getBuilder() {
         return AggregationBuilders.filter(getName()).filter(QueryBuilders.termQuery(getField(), getValue()));
     }

--- a/src/main/java/sirius/search/aggregation/bucket/TermAggregation.java
+++ b/src/main/java/sirius/search/aggregation/bucket/TermAggregation.java
@@ -38,6 +38,7 @@ public class TermAggregation extends BucketAggregation {
      *
      * @return the termbuilder
      */
+    @Override
     public TermsBuilder getBuilder() {
         return AggregationBuilders.terms(getName()).field(getField()).size(getSize());
     }

--- a/src/main/java/sirius/search/aggregation/metrics/MaxAggregation.java
+++ b/src/main/java/sirius/search/aggregation/metrics/MaxAggregation.java
@@ -38,6 +38,7 @@ public class MaxAggregation extends MetricsAggregation {
      *
      * @return the max-builder
      */
+    @Override
     public MaxBuilder getBuilder() {
         return AggregationBuilders.max(getName()).field(getField());
     }

--- a/src/main/java/sirius/search/aggregation/metrics/MinAggregation.java
+++ b/src/main/java/sirius/search/aggregation/metrics/MinAggregation.java
@@ -38,6 +38,7 @@ public class MinAggregation extends MetricsAggregation {
      *
      * @return the min-builder
      */
+    @Override
     public MinBuilder getBuilder() {
         return AggregationBuilders.min(getName()).field(getField());
     }

--- a/src/main/java/sirius/search/properties/CompleterProperty.java
+++ b/src/main/java/sirius/search/properties/CompleterProperty.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.search.annotations.FastCompletion;
-import sirius.search.annotations.NestedObject;
 import sirius.search.suggestion.AutoCompletion;
 
 import java.io.IOException;

--- a/src/main/java/sirius/search/properties/ObjectProperty.java
+++ b/src/main/java/sirius/search/properties/ObjectProperty.java
@@ -13,7 +13,6 @@ import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.kernel.nls.NLS;
 import sirius.search.IndexAccess;
-import sirius.search.annotations.FastCompletion;
 import sirius.search.annotations.NestedObject;
 import sirius.search.annotations.Transient;
 

--- a/src/main/java/sirius/search/suggestion/Complete.java
+++ b/src/main/java/sirius/search/suggestion/Complete.java
@@ -40,6 +40,12 @@ public class Complete<E extends Entity> {
     private List<String> contextValues;
     private Fuzziness fuzziness;
 
+    /**
+     * Creates a new completion for the given index access and entity type.
+     *
+     * @param index the instance of <tt>IndexAccess</tt> being used
+     * @param clazz the entity type to operate on
+     */
     public Complete(IndexAccess index, Class<E> clazz) {
         this.index = index;
         this.clazz = clazz;


### PR DESCRIPTION
Makes DEFAULT_FIELD and defaultAnalyzer() of Query public

This helps to create a custom instance of RobustQueryParser in case
the generated constraint needs to be put into a complex query
like an OR with other searches.