### PR TITLE
Allows the query size to be zero

### DIFF
--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -825,7 +825,7 @@ public class Query<E extends Entity> {
         if (start > 0) {
             srb.setFrom(start);
         }
-        if (limit != null && limit > 0) {
+        if (limit != null && limit >= 0) {
             srb.setSize(limit);
         }
     }

--- a/src/main/java/sirius/search/aggregation/bucket/Filters.java
+++ b/src/main/java/sirius/search/aggregation/bucket/Filters.java
@@ -29,6 +29,7 @@ public class Filters extends BucketAggregation {
      * Sets the filters that should be combined using must-clauses
      *
      * @param filters the filters that should be combined
+     * @return a newly created filters aggregation helper
      */
     public static Filters of(Filter... filters) {
         Filters multipleFilters = new Filters("");


### PR DESCRIPTION
Can be used, if a query should generate only aggregations and don’t fetch search hits