### PR TITLE
Increase elastic search version, fine grained scripting parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.7.1</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>2.8.2</version>
+    <version>2.8.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.4</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/src/main/java/sirius/search/IndexAccess.java
+++ b/src/main/java/sirius/search/IndexAccess.java
@@ -523,7 +523,6 @@ public class IndexAccess {
                                         .put("index.gateway.type", "none")
                                         .put("index.number_of_shards", 1)
                                         .put("index.number_of_replicas", 0)
-                                        .put("script.disable_dynamic", false)
                                         .build();
             inMemoryNode = new ConfigurableNode(settings, Collections.singletonList(GroovyPlugin.class)).start();
             client = inMemoryNode.client();

--- a/src/main/java/sirius/search/IndexAccess.java
+++ b/src/main/java/sirius/search/IndexAccess.java
@@ -523,6 +523,8 @@ public class IndexAccess {
                                         .put("index.gateway.type", "none")
                                         .put("index.number_of_shards", 1)
                                         .put("index.number_of_replicas", 0)
+                                        .put("script.inline", "on")
+                                        .put("script.indexed", "on")
                                         .build();
             inMemoryNode = new ConfigurableNode(settings, Collections.singletonList(GroovyPlugin.class)).start();
             client = inMemoryNode.client();


### PR DESCRIPTION
Increase the elastic search version as indexExists() is broken for embedded nodes in 2.3.1
(https://github.com/elastic/elasticsearch/pull/19047).
Remove script.disable_dynamic as start parameter which is not allowed.