### PR TITLE
Don’t use ObjectProperty if the field type is AutoCompletion as we ha…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.8.3</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/properties/ObjectProperty.java
+++ b/src/main/java/sirius/search/properties/ObjectProperty.java
@@ -15,6 +15,7 @@ import sirius.kernel.nls.NLS;
 import sirius.search.IndexAccess;
 import sirius.search.annotations.NestedObject;
 import sirius.search.annotations.Transient;
+import sirius.search.suggestion.AutoCompletion;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -37,7 +38,7 @@ public class ObjectProperty extends Property {
 
         @Override
         public boolean accepts(Field field) {
-            return field.isAnnotationPresent(NestedObject.class);
+            return field.isAnnotationPresent(NestedObject.class) && !field.getType().equals(AutoCompletion.class);
         }
 
         @Override


### PR DESCRIPTION
…ve a own property for this use case