### PR TITLE
Fixes Bugs of #95 Makes it possible to store abstract Entities in the index

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>1.10</version>
+    <version>1.10.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/EntityDescriptor.java
+++ b/src/main/java/sirius/search/EntityDescriptor.java
@@ -290,6 +290,16 @@ public class EntityDescriptor {
     }
 
     /**
+     * Returns true if this descriptor has a {@link #getSubClassCode() subClassCode} and a {@link #getParent() parent
+     * descriptor}.
+     *
+     * @return true if this descriptor is a subclass descriptor, false otherwise
+     */
+    public boolean isSubClassDescriptor() {
+        return Strings.isFilled(getSubClassCode());
+    }
+
+    /**
      * Returns the descriptors of subclasses of this descriptor's {@link #getEntityType() class object}. This is only
      * used in combination with <strong>subclass-codes</strong> and is therefore only filled if this descriptor belongs
      * to an abstract parent class!
@@ -302,9 +312,21 @@ public class EntityDescriptor {
     }
 
     /**
-     * Creates the mapping required by ElasticSearch to store entities related to this descriptor.
+     * Returns true if this descriptor relates to an abstract {@link Entity} and has child descriptors from
+     * concrete subclasses.
      *
-     * @return a JSON structure defining the mapping of this descriptor
+     * @return true if this descriptor is a parent descriptor, false otherwise
+     */
+    public boolean isParentDescriptor() {
+        return !getSubClassDescriptors().isEmpty();
+    }
+
+    /**
+     * Creates the mapping required by ElasticSearch to store entities related to this descriptor. If this descriptor is
+     * a {@link #isSubClassDescriptor() subClass descriptor}, <tt>null</tt> is returned.
+     *
+     * @return a JSON structure defining the mapping of this descriptor or <tt>null</tt> if this descriptor is a {@link
+     * #isSubClassDescriptor() subClass descriptor}
      * @throws IOException in case of an IO error during the JSON encoding
      */
     public XContentBuilder createMapping() throws IOException {
@@ -313,7 +335,11 @@ public class EntityDescriptor {
         for (Property p : getProperties()) {
             p.createMapping(builder);
         }
-        createSubClassCodeMapping(builder);
+
+        if (isParentDescriptor()) {
+            createSubClassCodeMapping(builder);
+        }
+
         builder.endObject();
         if (Strings.isFilled(routing)) {
             builder.startObject("_routing");
@@ -327,7 +353,7 @@ public class EntityDescriptor {
     private void createSubClassCodeMapping(XContentBuilder builder) throws IOException {
         builder.startObject(Index.SUBCLASSCODE_FIELD);
         builder.field("type", "string");
-        builder.field("store", "yes");
+        builder.field("store", "no");
         builder.field("index", IndexMode.MODE_NOT_ANALYZED);
         builder.startObject("norms");
         builder.field("enabled", IndexMode.NORMS_DISABLED);

--- a/src/main/java/sirius/search/Index.java
+++ b/src/main/java/sirius/search/Index.java
@@ -829,7 +829,7 @@ public class Index {
                  .get(10, TimeUnit.SECONDS);
         } catch (Exception ex) {
             Throwable cause = ex;
-            while (ex.getCause() != null && ex.getCause() != ex) {
+            while (cause.getCause() != null && cause.getCause() != ex) {
                 cause = ex.getCause();
             }
             throw Exceptions.handle()

--- a/src/main/java/sirius/search/Index.java
+++ b/src/main/java/sirius/search/Index.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
@@ -937,7 +938,7 @@ public class Index {
             entity.beforeSave();
             EntityDescriptor descriptor = getDescriptor(entity.getClass());
             descriptor.writeTo(entity, source);
-            if (Strings.isFilled(descriptor.getSubClassCode())) {
+            if (descriptor.isSubClassDescriptor()) {
                 source.put(SUBCLASSCODE_FIELD, descriptor.getSubClassCode());
             }
 
@@ -1576,16 +1577,16 @@ public class Index {
     }
 
     private static <E extends Entity> E createEntity(@Nonnull Class<E> clazz,
-                                                    @Nonnull String id,
-                                                    long version,
-                                                    @Nonnull Map<String, Object> source)
+                                                     @Nonnull String id,
+                                                     long version,
+                                                     @Nonnull Map<String, Object> source)
             throws IllegalAccessException, InstantiationException {
         EntityDescriptor descriptor = getDescriptor(clazz);
         String subClassCode = (String) source.get(SUBCLASSCODE_FIELD);
         if (Modifier.isAbstract(clazz.getModifiers())) {
             return handleAbstractEntity(clazz, id, version, source, descriptor);
         }
-        if(Strings.isFilled(subClassCode) && !Strings.areEqual(descriptor.getSubClassCode(), subClassCode)) {
+        if (descriptor.isSubClassDescriptor() && !Strings.areEqual(descriptor.getSubClassCode(), subClassCode)) {
             return null;
         }
 

--- a/src/main/java/sirius/search/Schema.java
+++ b/src/main/java/sirius/search/Schema.java
@@ -85,7 +85,7 @@ public class Schema {
             descriptorTable.put(entityType, result);
             nameTable.put(result.getIndex() + "-" + result.getType(), entityType);
 
-            if (Strings.isFilled(result.getSubClassCode()) && !findAbstractParentClass(entityType, result)) {
+            if (result.isSubClassDescriptor() && !findAbstractParentClass(entityType, result)) {
                 Index.LOG.WARN(
                         "LOAD: Class %s has subClassCode but no abstract parent class with the same index name, type name and routing could be found",
                         entityType.getName());
@@ -139,13 +139,13 @@ public class Schema {
                                         EntityDescriptor parentClassDescriptor) {
         if (parentClassDescriptor.getSubClassDescriptors().containsKey(subClassDescriptor.getSubClassCode())) {
             Index.LOG.WARN("LOAD: Classes %s and %s have the same parent class %s and the same subclass-code \"%s\"!",
-                     subClass.getName(),
-                     parentClassDescriptor.getSubClassDescriptors()
-                                          .get(subClassDescriptor.getSubClassCode())
-                                          .getEntityType()
-                                          .getName(),
-                     parentClass,
-                     subClassDescriptor.getSubClassCode());
+                           subClass.getName(),
+                           parentClassDescriptor.getSubClassDescriptors()
+                                                .get(subClassDescriptor.getSubClassCode())
+                                                .getEntityType()
+                                                .getName(),
+                           parentClass,
+                           subClassDescriptor.getSubClassCode());
         } else {
             parentClassDescriptor.getSubClassDescriptors()
                                  .put(subClassDescriptor.getSubClassCode(), subClassDescriptor);
@@ -232,6 +232,9 @@ public class Schema {
         }
         for (Map.Entry<Class<? extends Entity>, EntityDescriptor> e : descriptorTable.entrySet()) {
             try {
+                if (e.getValue().isSubClassDescriptor()) {
+                    continue;
+                }
                 if (Index.LOG.isFINE()) {
                     Index.LOG.FINE("MAPPING OF %s : %s",
                                    e.getValue().getType(),

--- a/src/main/java/sirius/search/properties/Property.java
+++ b/src/main/java/sirius/search/properties/Property.java
@@ -20,6 +20,7 @@ import sirius.web.security.UserContext;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Objects;
 
 /**
  * A property describes how a field is persisted into the database and loaded back.
@@ -240,5 +241,23 @@ public class Property {
      */
     public String getFieldTitle() {
         return NLS.get(field.getDeclaringClass().getSimpleName() + "." + getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Property property = (Property) o;
+        return Objects.equals(getField().getType(), property.getField().getType())
+               && Objects.equals(getField().getName(), property.getField().getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getField());
     }
 }


### PR DESCRIPTION
#95 Makes it possible to store abstract Entities in the index

- Creates the subClassCode-Property only for mappings of abstract Entities
- Fixes endless loop when mapping creation throws an exception
- Creates no ES mappings for subclasses but only one for the abstract parent class