### PR TITLE
Fixes the true value of boolean term facets added to a query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>8.0</version>
+    <version>8.0.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -642,7 +642,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> addBooleanTermFacet(String field, String value) {
-        return addTermFacet(field, value, key -> NLS.get("T".equals(key) ? "NLS.yes" : "NLS.no"));
+        return addTermFacet(field, value, key -> NLS.get("true".equals(key) ? "NLS.yes" : "NLS.no"));
     }
 
     /**
@@ -653,7 +653,7 @@ public class Query<E extends Entity> {
      * @return the query itself for fluent method calls
      */
     public Query<E> addBooleanTermFacet(String field, WebContext request) {
-        return addTermFacet(field, request, key -> NLS.get("T".equals(key) ? "NLS.yes" : "NLS.no"));
+        return addTermFacet(field, request, key -> NLS.get("true".equals(key) ? "NLS.yes" : "NLS.no"));
     }
 
     /**


### PR DESCRIPTION
This is a backport of the same fix on sirius-search 9.0