### PR TITLE
Drop temporary indices not until in awaitTermination method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>8.0.3</version>
+    <version>8.0.4</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>8.0.2</version>
+    <version>8.0.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/IndexLifecycle.java
+++ b/src/main/java/sirius/search/IndexLifecycle.java
@@ -50,8 +50,6 @@ public class IndexLifecycle implements Lifecycle {
             return;
         }
 
-        index.getSchema().dropTemporaryIndices();
-
         if (index.delayLineTimer != null) {
             index.delayLineTimer.cancel();
         }
@@ -63,6 +61,9 @@ public class IndexLifecycle implements Lifecycle {
             LOG.INFO("ElasticSearch is disabled! (index.host is not set)");
             return;
         }
+
+        // may take longer than 10 seconds
+        index.getSchema().dropTemporaryIndices();
 
         // We wait until this last call before we cut the connection to the database (elasticsearch) to permit
         // other stopping lifecycles access until the very end...


### PR DESCRIPTION
Because it sometimes needs more than 10 seconds:

```
...
11:48:50.620 INFO  [default-2|33360ms] index - Successfully deleted temporary index: test-1505382470317-test-rejectchildentity
11:48:50.718 INFO  [default-2|33458ms] index - Successfully deleted temporary index: test-1505382470317-test-rejectmanychildentity
11:48:50.821 INFO  [default-2|33562ms] index - Successfully deleted temporary index: test-1505382470317-test-setnullchildentity
11:48:50.895 WARN  [main|33635ms] sirius - Lifecycle 'sirius.search.IndexLifecycle@5c5d6175' (sirius.search.IndexLifecycle) did not stop within 10 seconds....
11:48:50.895 INFO  [default-18|33636ms] sirius - Stopping: tasks (Async Execution Engine)
11:48:50.897 INFO  [main|33638ms] sirius - ---------------------------------------------------------
11:48:50.897 INFO  [main|33638ms] sirius - Awaiting system halt...
11:48:50.897 INFO  [main|33638ms] sirius - ---------------------------------------------------------
11:48:50.897 INFO  [main|33638ms] sirius - Terminated: Distributed Work Queue (Took: 16 us)
...
11:48:50.905 ERROR [default-2|33646ms] index - Ein Fehler ist aufgetreten: Failed to delete temporary index test-1505382470317-test-setnullmanychildentity: NoNodeAvailableException[None of the configured nodes were available: [...]; nested: NodeDisconnectedException[...] disconnected]; (java.util.concurrent.ExecutionException)
...
11:48:52.450 INFO  [main|35190ms] sirius - Terminated: index (ElasticSearch) (Took: 1 Sekunde, 548 Millisekunden)
```