### PR TITLE
Removes warning when executing a sorted iterate query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.10</version>
+        <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
     <version>8.0.5</version>
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>8.0</version>
+            <version>8.10.3</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>6.10.1</version>
+            <version>7.1</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>6.10.1</version>
+            <version>7.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.10</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>8.0.4</version>
+    <version>8.0.5</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -1408,7 +1408,10 @@ public class Query<E extends Entity> {
     private SearchResponse createScroll(EntityDescriptor entityDescriptor) {
         SearchRequestBuilder srb = buildSearch();
 
-        srb.addSort("_doc", SortOrder.ASC);
+        if (orderBys.isEmpty()) {
+            // If no custom ordering is needed we sort by _doc which brings performance benefits
+            srb.addSort("_doc", SortOrder.ASC);
+        }
         srb.setFrom(0);
 
         // If a routing is present, we will only hit one shard. Therefore we fetch up to 50 documents.

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -1407,11 +1407,6 @@ public class Query<E extends Entity> {
 
     private SearchResponse createScroll(EntityDescriptor entityDescriptor) {
         SearchRequestBuilder srb = buildSearch();
-        if (!orderBys.isEmpty()) {
-            IndexAccess.LOG.WARN("An iterated query cannot be sorted! Use '.blockwise(...)'. Query: %s, Location: %s",
-                                 this,
-                                 ExecutionPoint.snapshot());
-        }
 
         srb.addSort("_doc", SortOrder.ASC);
         srb.setFrom(0);


### PR DESCRIPTION
Ths warning is no longer necessary as the underlying scroll query respects the provided ordering