### PR TITLE
Sbi/remove sorted iterate warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.scireum</groupId>
         <artifactId>sirius-parent</artifactId>
-        <version>3.10</version>
+        <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
     <version>10.0.1</version>
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>7.0</version>
+            <version>7.1</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>7.0</version>
+            <version>7.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>10.0.1</version>
+    <version>10.0.2</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -1403,7 +1403,10 @@ public class Query<E extends Entity> {
     private SearchResponse createScroll(EntityDescriptor entityDescriptor) {
         SearchRequestBuilder srb = buildSearch();
 
-        srb.addSort("_doc", SortOrder.ASC);
+        if (orderBys.isEmpty()) {
+            // If no custom ordering is needed we sort by _doc which brings performance benefits
+            srb.addSort("_doc", SortOrder.ASC);
+        }
         srb.setFrom(0);
 
         // If a routing is present, we will only hit one shard. Therefore we fetch up to 50 documents.

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -1402,11 +1402,6 @@ public class Query<E extends Entity> {
 
     private SearchResponse createScroll(EntityDescriptor entityDescriptor) {
         SearchRequestBuilder srb = buildSearch();
-        if (!orderBys.isEmpty()) {
-            IndexAccess.LOG.WARN("An iterated query cannot be sorted! Use '.blockwise(...)'. Query: %s, Location: %s",
-                                 this,
-                                 ExecutionPoint.snapshot());
-        }
 
         srb.addSort("_doc", SortOrder.ASC);
         srb.setFrom(0);


### PR DESCRIPTION
Removes warning when executing a sorted iterate query

This Ports PR https://github.com/scireum/sirius-search/pull/130 to version 10 of sirius-search