### PR TITLE
Bumps the ES-API to 6.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>10.1</version>
+    <version>11.0</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>
@@ -37,12 +37,8 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>5.4.0</version>
+            <version>6.1.0</version>
             <exclusions>
-                <exclusion>
-                    <artifactId>netty-common</artifactId>
-                    <groupId>io.netty</groupId>
-                </exclusion>
                 <exclusion>
                     <artifactId>netty-codec-http</artifactId>
                     <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,17 +20,17 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>16.1.1</version>
+            <version>16.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>7.4</version>
+            <version>9.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-kernel</artifactId>
-            <version>7.4</version>
+            <version>9.0.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>11.0</version>
+    <version>12.0</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
-            <version>11.3</version>
+            <version>16.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>
@@ -37,8 +37,12 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>6.1.0</version>
+            <version>6.2.4</version>
             <exclusions>
+                <exclusion>
+                    <artifactId>netty-common</artifactId>
+                    <groupId>io.netty</groupId>
+                </exclusion>
                 <exclusion>
                     <artifactId>netty-codec-http</artifactId>
                     <groupId>io.netty</groupId>

--- a/src/main/java/sirius/search/DateRange.java
+++ b/src/main/java/sirius/search/DateRange.java
@@ -8,7 +8,7 @@
 
 package sirius.search;
 
-import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
 import sirius.kernel.nls.NLS;
 import sirius.search.constraints.FieldOperator;
 

--- a/src/main/java/sirius/search/EntityDescriptor.java
+++ b/src/main/java/sirius/search/EntityDescriptor.java
@@ -41,6 +41,7 @@ public class EntityDescriptor {
     private final String annotatedIndexName;
     private String typeName;
     private String routing;
+    private boolean useAllField;
     private final Class<?> clazz;
     protected List<Property> properties;
     protected List<ForeignKey> foreignKeys;
@@ -63,6 +64,7 @@ public class EntityDescriptor {
         } else {
             this.indexName = annotatedIndexName + "-" + clazz.getSimpleName().toLowerCase();
         }
+        this.useAllField = clazz.getAnnotation(Indexed.class).useAllField();
         this.typeName = Strings.firstFilled(clazz.getAnnotation(Indexed.class).type(), clazz.getSimpleName());
         this.routing = clazz.getAnnotation(Indexed.class).routing();
         if (Strings.isEmpty(routing)) {
@@ -290,9 +292,15 @@ public class EntityDescriptor {
             }
 
             builder.startObject("properties");
+
+            if (useAllField) {
+                createCustomAllField(builder);
+            }
+
             for (Property p : getProperties()) {
                 p.createMapping(builder);
             }
+
             builder.endObject();
 
             builder.startArray("dynamic_templates");
@@ -303,6 +311,18 @@ public class EntityDescriptor {
 
             return builder.endObject().endObject();
         }
+    }
+
+    private void createCustomAllField(XContentBuilder builder) throws IOException {
+        builder.startObject("custom_all")
+               .field("type", "text")
+               .field("store", "false")
+               .field("index", "true")
+               .field("doc_values", "false")
+               .field("index_options", "docs")
+               .field("analyzer", "standard")
+               .field("norms", "false")
+               .endObject();
     }
 
     /**
@@ -359,5 +379,9 @@ public class EntityDescriptor {
      */
     public boolean hasForeignKeys() {
         return !foreignKeys.isEmpty();
+    }
+
+    public boolean isUseAllField() {
+        return useAllField;
     }
 }

--- a/src/main/java/sirius/search/ForeignKey.java
+++ b/src/main/java/sirius/search/ForeignKey.java
@@ -40,7 +40,7 @@ import java.util.List;
  */
 public class ForeignKey {
 
-    private static final String LANGUAGE_GROOVY = "groovy";
+    private static final String LANGUAGE_PAINLESS = "painless";
 
     private final RefType refType;
     private String otherType;
@@ -378,7 +378,7 @@ public class ForeignKey {
         for (Reference ref : references) {
             sb.append("ctx._source.");
             sb.append(ref.getLocalProperty().getName());
-            sb.append("=");
+            sb.append("=params.");
             sb.append(ref.getLocalProperty().getName());
             sb.append(";");
             ctx.put(ref.getLocalProperty().getName(),
@@ -387,12 +387,12 @@ public class ForeignKey {
         if (updateParent) {
             sb.append("ctx._source.");
             sb.append(getName());
-            sb.append("=");
+            sb.append("=params.");
             sb.append(getName());
             sb.append(";");
             ctx.put(getName(), parent != null ? parent.getId() : null);
         }
-        return new Script(ScriptType.INLINE, LANGUAGE_GROOVY, sb.toString(), ctx);
+        return new Script(ScriptType.INLINE, LANGUAGE_PAINLESS, sb.toString(), ctx);
     }
 
     /**

--- a/src/main/java/sirius/search/IndexAccess.java
+++ b/src/main/java/sirius/search/IndexAccess.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import sirius.kernel.Sirius;
@@ -487,8 +487,7 @@ public class IndexAccess {
         Settings settings = Settings.builder().put("cluster.name", clusterName).build();
         TransportClient transportClient = new PreBuiltTransportClient(settings);
         try {
-            transportClient.addTransportAddress(new InetSocketTransportAddress(InetAddress.getByName(hostAddress),
-                                                                               port));
+            transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName(hostAddress), port));
         } catch (UnknownHostException e) {
             Exceptions.handle(LOG, e);
         }

--- a/src/main/java/sirius/search/Query.java
+++ b/src/main/java/sirius/search/Query.java
@@ -25,7 +25,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -91,7 +91,7 @@ public class Query<E extends Entity> {
      * Specifies tbe default field to search in used by {@link #query(String)}. Use
      * {@link #query(String, String, Function, boolean, boolean)} to specify a custom field.
      */
-    public static final String DEFAULT_FIELD = "_all";
+    public static final String DEFAULT_FIELD = "custom_all";
 
     @ConfigValue("index.termFacetLimit")
     private static int termFacetLimit;
@@ -1005,7 +1005,7 @@ public class Query<E extends Entity> {
                                  indexAccess.getIndex(clazz),
                                  indexAccess.getDescriptor(clazz).getType(),
                                  response.getHits().getTotalHits(),
-                                 response.getTookInMillis());
+                                 response.getTook().millis());
         }
 
         if (defaultLimitEnforced && response.getHits().getHits().length == DEFAULT_LIMIT) {
@@ -1035,7 +1035,7 @@ public class Query<E extends Entity> {
             entity.initSourceTracing();
             entity.setId(searchHit.getId());
             entity.setVersion(searchHit.getVersion());
-            descriptor.readSource(entity, searchHit.getSource());
+            descriptor.readSource(entity, searchHit.getSourceAsMap());
 
             return entity;
         } catch (Exception e) {
@@ -1150,7 +1150,7 @@ public class Query<E extends Entity> {
             entity.initSourceTracing();
             entity.setId(hit.getId());
             entity.setVersion(hit.getVersion());
-            descriptor.readSource(entity, hit.getSource());
+            descriptor.readSource(entity, hit.getSourceAsMap());
             result.getResults().add(entity);
         }
         if (IndexAccess.LOG.isFINE()) {
@@ -1158,7 +1158,7 @@ public class Query<E extends Entity> {
                                  indexAccess.getIndex(clazz),
                                  indexAccess.getDescriptor(clazz).getType(),
                                  searchResponse.getHits().getTotalHits(),
-                                 searchResponse.getTookInMillis());
+                                 searchResponse.getTook().millis());
         }
         if (Microtiming.isEnabled()) {
             w.submitMicroTiming("ES", "LIST: " + toString(true));
@@ -1183,14 +1183,14 @@ public class Query<E extends Entity> {
             result.initSourceTracing();
             result.setId(hit.getId());
             result.setVersion(hit.getVersion());
-            indexAccess.getDescriptor(clazz).readSource(result, hit.getSource());
+            indexAccess.getDescriptor(clazz).readSource(result, hit.getSourceAsMap());
         }
         if (IndexAccess.LOG.isFINE()) {
             IndexAccess.LOG.FINE("SEARCH-FIRST: %s.%s: SUCCESS: %d - %d ms",
                                  indexAccess.getIndex(clazz),
                                  indexAccess.getDescriptor(clazz).getType(),
                                  searchResponse.getHits().getTotalHits(),
-                                 searchResponse.getTookInMillis());
+                                 searchResponse.getTook().millis());
         }
         if (Microtiming.isEnabled()) {
             w.submitMicroTiming("ES", "FIRST: " + toString(true));
@@ -1327,7 +1327,7 @@ public class Query<E extends Entity> {
             entity.setId(hit.getId());
             entity.initSourceTracing();
             entity.setVersion(hit.getVersion());
-            entityDescriptor.readSource(entity, hit.getSource());
+            entityDescriptor.readSource(entity, hit.getSourceAsMap());
 
             if (lim.nextRow()) {
                 if (!handler.handleRow(entity)) {
@@ -1390,7 +1390,7 @@ public class Query<E extends Entity> {
                                  entityDescriptor.getType(),
                                  searchResponse.getHits().getHits().length,
                                  searchResponse.getHits().getTotalHits(),
-                                 searchResponse.getTookInMillis());
+                                 searchResponse.getTook().millis());
         }
         return searchResponse;
     }

--- a/src/main/java/sirius/search/annotations/Indexed.java
+++ b/src/main/java/sirius/search/annotations/Indexed.java
@@ -36,6 +36,13 @@ public @interface Indexed {
     String type() default "";
 
     /**
+     * Determines whether the entity should provide a _all-field emulation (as this is deprecated since ES-6.0).
+     *
+     * @return <tt>true</tt> if a _all-field emulation should be provided <tt>false</tt> otherwise.
+     */
+    boolean useAllField() default true;
+
+    /**
      * Determines the field used for custom routing.
      *
      * @return the field name used for custom routing (Note that routing values for search requests need to be

--- a/src/main/java/sirius/search/properties/Property.java
+++ b/src/main/java/sirius/search/properties/Property.java
@@ -17,6 +17,7 @@ import sirius.kernel.nls.NLS;
 import sirius.search.Entity;
 import sirius.search.EntityDescriptor;
 import sirius.search.IndexAccess;
+import sirius.search.annotations.Analyzed;
 import sirius.search.annotations.IndexMode;
 import sirius.search.annotations.Indexed;
 import sirius.search.annotations.NotNull;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -328,12 +330,18 @@ public abstract class Property {
                 builder.field("index", isIndexed());
             }
         }
-        if (isIncludeInAll() != ESOption.ES_DEFAULT) {
-            builder.field("include_in_all", isIncludeInAll());
+
+        if (!isMapProperty() && isIncludeInAll() == ESOption.TRUE) {
+            builder.field("copy_to", "custom_all");
         }
+
         if (isDocValuesEnabled() != ESOption.ES_DEFAULT) {
             builder.field("doc_values", isDocValuesEnabled());
         }
+    }
+
+    private boolean isMapProperty() {
+        return this instanceof StringMapProperty || this instanceof StringListMapProperty;
     }
 
     /**

--- a/src/main/java/sirius/search/properties/StringMapProperty.java
+++ b/src/main/java/sirius/search/properties/StringMapProperty.java
@@ -10,6 +10,7 @@ package sirius.search.properties;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import sirius.kernel.commons.Context;
+import sirius.kernel.commons.Strings;
 import sirius.kernel.di.std.Register;
 import sirius.kernel.health.Exceptions;
 import sirius.search.Entity;
@@ -104,10 +105,16 @@ public class StringMapProperty extends StringProperty {
 
         builder.startObject(KEY);
         builder.field("type", "keyword");
+        if (Strings.areEqual("true", includeInAll.getValue())) {
+            builder.field("copy_to", "custom_all");
+        }
         builder.endObject();
 
         builder.startObject(VALUE);
         builder.field("type", super.getMappingType());
+        if (Strings.areEqual("true", includeInAll.getValue())) {
+            builder.field("copy_to", "custom_all");
+        }
         builder.endObject();
 
         builder.endObject();

--- a/src/main/java/sirius/search/suggestion/Suggest.java
+++ b/src/main/java/sirius/search/suggestion/Suggest.java
@@ -8,6 +8,7 @@
 
 package sirius.search.suggestion;
 
+import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -43,7 +44,7 @@ public class Suggest<E extends Entity> {
     private Map<String, Object> collateParams;
     private boolean collatePrune;
     private Tuple<String, String> highlightTags;
-    private ListenableActionFuture<SearchResponse> future;
+    private ActionFuture<SearchResponse> future;
 
     /**
      * Used to create a new suggestion for entities of the given class


### PR DESCRIPTION
Adjust to Java-API-changes, change scripting language to painless, provide a alternative to the _all-field
by using a custom-_all field using the copy_to attribute.