### PR TITLE
Enhances FieldNotEqual Constraint for null Values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.11.2</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>10.3</version>
+    <version>11</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/test/java/sirius/search/FieldNotEqualSpec.groovy
+++ b/src/test/java/sirius/search/FieldNotEqualSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Made with all the love in the world
+ * by scireum in Remshalden, Germany
+ *
+ * Copyright by scireum GmbH
+ * http://www.scireum.de - info@scireum.de
+ */
+
+package sirius.search
+
+import sirius.kernel.BaseSpecification
+import sirius.kernel.di.std.Part
+import sirius.search.constraints.FieldNotEqual
+import sirius.search.entities.QueryEntity
+
+class FieldNotEqualSpec extends BaseSpecification {
+    
+    @Part
+    private static IndexAccess index
+    
+    def "FieldNotEqual with null values finds filled entities"() {
+        given:
+        QueryEntity e = new QueryEntity()
+        e.setContent("fieldnotequal")
+        when:
+        index.update(e)
+        and:
+        index.blockThreadForUpdate()
+        Optional result = index.select(QueryEntity.class)
+                .notEq(QueryEntity.CONTENT, null)
+                .first()
+        then:
+        result.isPresent()
+    }
+
+    def "FieldNotEqual with null values and id field finds entities"() {
+        given:
+        QueryEntity e = new QueryEntity()
+        e.setContent("fieldnotequal")
+        when:
+        index.update(e)
+        and:
+        index.blockThreadForUpdate()
+        Optional result = index.select(QueryEntity.class)
+                .notEq(QueryEntity.CONTENT, null)
+                .first()
+        then:
+        result.isPresent()
+    }
+
+    def "FieldNotEqual with null values and ignoreNull finds empty content"() {
+        given:
+        QueryEntity e = new QueryEntity()
+        e.setContent("")
+        when:
+        index.update(e)
+        and:
+        index.blockThreadForUpdate()
+        Optional result = index.select(QueryEntity.class)
+                .where(FieldNotEqual.on(QueryEntity.CONTENT, null).ignoreNull())
+                .first()
+        then:
+        result.isPresent()
+    }
+
+    def "FieldNotEqual with null values and ignoreNull finds id"() {
+        given:
+        QueryEntity e = new QueryEntity()
+        when:
+        index.update(e)
+        and:
+        index.blockThreadForUpdate()
+        Optional result = index.select(QueryEntity.class)
+                .where(FieldNotEqual.on(QueryEntity.CONTENT, null).ignoreNull())
+                .first()
+        then:
+        result.isPresent()
+    }
+}

--- a/src/test/java/sirius/search/FieldNotEqualSpec.groovy
+++ b/src/test/java/sirius/search/FieldNotEqualSpec.groovy
@@ -42,7 +42,7 @@ class FieldNotEqualSpec extends BaseSpecification {
         and:
         index.blockThreadForUpdate()
         Optional result = index.select(QueryEntity.class)
-                .notEq(QueryEntity.CONTENT, null)
+                .notEq(QueryEntity.ID, null)
                 .first()
         then:
         result.isPresent()
@@ -71,7 +71,7 @@ class FieldNotEqualSpec extends BaseSpecification {
         and:
         index.blockThreadForUpdate()
         Optional result = index.select(QueryEntity.class)
-                .where(FieldNotEqual.on(QueryEntity.CONTENT, null).ignoreNull())
+                .where(FieldNotEqual.on(QueryEntity.ID, null).ignoreNull())
                 .first()
         then:
         result.isPresent()

--- a/src/test/java/sirius/search/QueriesSpec.groovy
+++ b/src/test/java/sirius/search/QueriesSpec.groovy
@@ -13,16 +13,11 @@ import org.elasticsearch.index.query.functionscore.FieldValueFactorFunctionBuild
 import sirius.kernel.BaseSpecification
 import sirius.kernel.annotations.SetupOnce
 import sirius.kernel.di.std.Part
-import sirius.search.constraints.And
-import sirius.search.constraints.Constraint
-import sirius.search.constraints.FieldEqual
-import sirius.search.constraints.NearSpan
-import sirius.search.constraints.Or
+import sirius.search.constraints.*
 import sirius.search.entities.CustomAnalyzerPropertyEntity
 import sirius.search.entities.ParentEntity
 import sirius.search.entities.QueryEntity
 import sirius.web.controller.Page
-import sirius.search.constraints.Named
 
 class QueriesSpec extends BaseSpecification {
 
@@ -52,7 +47,7 @@ class QueriesSpec extends BaseSpecification {
         index.select(ParentEntity.class).query("name:- id:" + e.getId()).count() == 1
         index.select(ParentEntity.class).query("-name:- id:" + e.getId()).count() == 0
     }
-    
+
     def "robust query can produce OR query"() {
         given:
         ParentEntity e1 = new ParentEntity()


### PR DESCRIPTION
- Simplfied Constraint:
Instead of Mustnot.Mustnot.Exists it now is simply Exists
- Works with ID field:
Previously notEq("id", null) returned no Entities, now it returns all Entities
- Added ignoreNull option
when set to true, the constraint will not be created on null values