### PR TITLE
Fix metrics for queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>11.8</version>
+    <version>11.8.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/IndexReport.java
+++ b/src/main/java/sirius/search/IndexReport.java
@@ -52,12 +52,8 @@ public class IndexReport implements MetricProvider {
                                      "ES-OptimisticLock-Errors",
                                      index.optimisticLockErrors.getCount(),
                                      "/min");
+        collector.metric("index-queries", "ES-Queries", index.queryDuration.getCount(), "/min");
         collector.metric("index-queryDuration", "ES-QueryDuration", index.queryDuration.getAndClear(), "ms");
-        collector.differentialMetric("index-queries",
-                                     "index-queries",
-                                     "ES-Queries",
-                                     index.queryDuration.getCount(),
-                                     "/min");
     }
 
     private MetricState asMetricState(ClusterHealthStatus status) {


### PR DESCRIPTION
These metrics were cleared before being output. Furthermore, due to changes in the Average class now the ES-Queries are not a differential metric any longer.