### PR TITLE
Prevents tokens starting with and / or from being interpreted as such

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>11.9</version>
+    <version>11.9.1</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>

--- a/src/main/java/sirius/search/constraints/RobustQueryParser.java
+++ b/src/main/java/sirius/search/constraints/RobustQueryParser.java
@@ -189,12 +189,12 @@ public class RobustQueryParser implements Constraint {
      */
     protected QueryBuilder parseAND(LookaheadReader reader) {
         List<QueryBuilder> result = Lists.newArrayList();
-        QueryBuilder subQuery = parseToken(reader);
-        if (subQuery != null) {
-            result.add(subQuery);
-        }
 
         while (!reader.current().isEndOfInput() && !reader.current().is(')')) {
+            QueryBuilder subQuery = parseToken(reader);
+            if (subQuery != null) {
+                result.add(subQuery);
+            }
             skipWhitespace(reader);
             if (isAtOR(reader)) {
                 break;
@@ -206,10 +206,6 @@ public class RobustQueryParser implements Constraint {
             if (isAtBinaryAND(reader)) {
                 // && is the default operation -> ignore
                 reader.consume(2);
-            }
-            subQuery = parseToken(reader);
-            if (subQuery != null) {
-                result.add(subQuery);
             }
         }
 
@@ -246,6 +242,8 @@ public class RobustQueryParser implements Constraint {
      * Parses a token or an expression in brackets
      */
     protected QueryBuilder parseToken(LookaheadReader reader) {
+        skipWhitespace(reader);
+
         if (reader.current().is('(')) {
             return parseTokenInBrackets(reader);
         }

--- a/src/test/java/sirius/search/QueriesSpec.groovy
+++ b/src/test/java/sirius/search/QueriesSpec.groovy
@@ -14,7 +14,6 @@ import sirius.kernel.BaseSpecification
 import sirius.kernel.annotations.SetupOnce
 import sirius.kernel.di.std.Part
 import sirius.search.constraints.And
-import sirius.search.constraints.Constraint
 import sirius.search.constraints.FieldEqual
 import sirius.search.constraints.NearSpan
 import sirius.search.constraints.Or
@@ -66,6 +65,21 @@ class QueriesSpec extends BaseSpecification {
         index.blockThreadForUpdate()
         then:
         index.select(ParentEntity.class).query("one OR two").count() == 2
+    }
+
+    def "robust query won't mistake tokens beginning with boolean operations as such"() {
+        given:
+        ParentEntity e1 = new ParentEntity()
+        e1.setName("quote order")
+        ParentEntity e2 = new ParentEntity()
+        e2.setName("der")
+        when:
+        e1 = index.update(e1)
+        e2 = index.update(e2)
+        and:
+        index.blockThreadForUpdate()
+        then:
+        index.select(ParentEntity.class).query("quote AND order").count() == 1
     }
 
     def "robust query can produce complex nested query"() {


### PR DESCRIPTION
... these would previously result in a wrong query with shortened second tokens and in some cases wrong boolean operations.

e.g. "quote AND order" would result in "quote OR der"

Fixes: OX-4482