### PR TITLE
Transforms sirius-db entities and refs given in filters into their id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>3.14</version>
     </parent>
     <artifactId>sirius-search</artifactId>
-    <version>11.12.2</version>
+    <version>11.12.3</version>
     <packaging>jar</packaging>
 
     <name>SIRIUS Search</name>
@@ -19,6 +19,7 @@
     <properties>
         <sirius.kernel>13.18</sirius.kernel>
         <sirius.web>24.0.1</sirius.web>
+        <sirius.db>10.3</sirius.db>
     </properties>
 
     <repositories>
@@ -33,6 +34,11 @@
             <groupId>com.scireum</groupId>
             <artifactId>sirius-web</artifactId>
             <version>${sirius.web}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.scireum</groupId>
+            <artifactId>sirius-db</artifactId>
+            <version>${sirius.db}</version>
         </dependency>
         <dependency>
             <groupId>com.scireum</groupId>

--- a/src/main/java/sirius/search/constraints/FieldEqual.java
+++ b/src/main/java/sirius/search/constraints/FieldEqual.java
@@ -11,6 +11,8 @@ package sirius.search.constraints;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.SpanQueryBuilder;
+import sirius.db.mixing.BaseEntity;
+import sirius.db.mixing.types.BaseEntityRef;
 import sirius.kernel.commons.Strings;
 import sirius.kernel.commons.Value;
 import sirius.search.Entity;
@@ -76,6 +78,12 @@ public class FieldEqual implements Constraint, SpanConstraint {
             } else {
                 return DateTimeFormatter.ISO_LOCAL_DATE.format((TemporalAccessor) value);
             }
+        }
+        if (value instanceof BaseEntityRef) {
+            return ((BaseEntityRef<?, ?>) value).getIdAsString();
+        }
+        if (value instanceof BaseEntity) {
+            return ((BaseEntity<?>) value).getIdAsString();
         }
 
         return value;


### PR DESCRIPTION
While migrating from search to db it can happen that old queries are affected, and new entities are injected as filter values. With this change, this will still work instead of producing errors.